### PR TITLE
Reconnect method added to recover mochad connection

### DIFF
--- a/pymochad/controller.py
+++ b/pymochad/controller.py
@@ -54,6 +54,23 @@ class PyMochad(object):
                 "Unable to connect to server %s" % self.server)
         self.socket.setblocking(0)
 
+    def reconnect(self):
+        """Reconnect when mochad server is restarted/lost connection."""
+        if self.socket:
+            self.socket.close()
+        for addr in socket.getaddrinfo(self.server, self.port):
+            af, socktype, proto, cannonname, sa = addr
+            try:
+                self.socket = socket.socket(af, socktype, proto)
+                self.socket.connect(sa)
+            except Exception:
+                continue
+            break
+        else:
+            raise exceptions.ConfigurationError(
+                "Unable to connect to server %s" % self.server)
+        self.socket.setblocking(0)
+        
     def send_cmd(self, cmd):
         """Send a raw command to mochad.
 


### PR DESCRIPTION
pyMochad controller is used in complex projects like home-assistant. Once instance is created it is referenced by multiple other instances.  Each time network socket becomes disconnected, there is no way to recover unless creating new instance of pyMochad and then updating all references. 

In order to simplify that process and make pyMochad better fit reliable applications, I added a reconnect method.