### PR TITLE
Fix for hanging when data received ends with "\n\r"

### DIFF
--- a/pymochad/controller.py
+++ b/pymochad/controller.py
@@ -85,7 +85,8 @@ class PyMochad(object):
                     break
                 total_data.append(six.text_type(data.decode('utf8')))
                 line_break = six.binary_type('\n'.encode('utf8'))
-                if data.endswith(line_break):
+                alt_line_break = six.binary_type('\n\r'.encode('utf8'))
+                if data.endswith(line_break) or data.endswith(alt_line_break):
                     break
             except socket.error as e:
                 if e.errno == socket.errno.EWOULDBLOCK:


### PR DESCRIPTION
I was running into an issue with hanging during any time `read_data()` was called. Turns out the messages returned by mochad were terminated with `\n\r`, not just `\n`. 
My mochad setup was obtained from [this new fork](https://github.com/sigmdel/mochad), which appears to have these changes deliberately put in, and archives of the original mochad source code seem to show commands ending with just one `\n`.
Nonetheless, I made a simple change which appears to completely resolve the issue for these new installations of mochad, and should not break compatibility with older mochad setups.

I greatly appreciate you taking the time to review this as my current Home Assistant setup relies on this package, Thanks!